### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "less": "^2.7.1",
     "less-plugin-npm-import": "^2.1.0",
     "node-sass": "^3.11.2",
-    "node-uuid": "^1.4.7",
     "postcss": "^5.2.5",
-    "react": "^15.3.2"
+    "react": "^15.3.2",
+    "uuid": "^3.0.0"
   },
   "description": "Pre-compile and inject scoped css for styling react components",
   "devDependencies": {

--- a/src/transformStyles.js
+++ b/src/transformStyles.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 const {
   generateTransformedStylesFile


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.